### PR TITLE
fix(HoverIndicator): 修复鼠标移入指示器区域时意外隐藏的问题

### DIFF
--- a/changelog/2026-03-30.md
+++ b/changelog/2026-03-30.md
@@ -1,0 +1,4 @@
+# 2026-03-30
+
+## Fixed
+- 修复 HoverIndicator 鼠标移入立即隐藏的问题：将块元素检测从 `target.closest()` 改为按鼠标 Y 坐标匹配块元素，解决鼠标位于 ProseMirror padding 区域时指示器意外隐藏的 bug

--- a/src/components/BEditor/hooks/useHoverIndicator.ts
+++ b/src/components/BEditor/hooks/useHoverIndicator.ts
@@ -16,12 +16,11 @@ interface UseHoverIndicatorResult {
   onContainerMouseMove: (event: MouseEvent) => void;
 }
 
+// 指示器高度的一半，用于扩展块的命中区域，防止鼠标在指示器边缘时隐藏
+const INDICATOR_HALF_HEIGHT = 14;
+
 const BLOCK_SELECTOR =
   '.b-editor-content h1, .b-editor-content h2, .b-editor-content h3, .b-editor-content h4, .b-editor-content h5, .b-editor-content h6, .b-editor-content p';
-
-function isTrackedBlock(element: Element): element is HTMLElement {
-  return element instanceof HTMLElement && /^(H[1-6]|P)$/.test(element.tagName);
-}
 
 function getIndicatorLabel(block: HTMLElement): string {
   if (block.tagName === 'P') {
@@ -58,15 +57,19 @@ export function useHoverIndicator(containerRef: Ref<HTMLElement | null>): UseHov
 
   function onContainerMouseMove(event: MouseEvent): void {
     const container = containerRef.value;
-    const { target } = event;
 
-    if (!(container && target instanceof Element)) {
+    if (!container) {
       hideIndicator();
       return;
     }
 
-    const block = target.closest(BLOCK_SELECTOR);
-    if (!(block && isTrackedBlock(block) && container.contains(block))) {
+    const blocks = container.querySelectorAll<HTMLElement>(BLOCK_SELECTOR);
+    const block = Array.from(blocks).find((b) => {
+      const rect = b.getBoundingClientRect();
+      return event.clientY >= rect.top - INDICATOR_HALF_HEIGHT && event.clientY <= rect.bottom + INDICATOR_HALF_HEIGHT;
+    });
+
+    if (!block) {
       hideIndicator();
       return;
     }


### PR DESCRIPTION
- 将块元素检测从 target.closest() 改为按鼠标 Y 坐标匹配，解决鼠标在 ProseMirror padding 区域时指示器隐藏的 bug
- 扩展 Y 坐标命中区域上下各 14px，防止鼠标在指示器边缘（超出短块边界）时闪烁隐藏